### PR TITLE
#40 Unsubscribe cleanup

### DIFF
--- a/server/scripts/twilio/actions.js
+++ b/server/scripts/twilio/actions.js
@@ -2,16 +2,36 @@ const knexConfig = require('../../../knexfile');
 const knex = require('knex')(knexConfig);
 const respondToUser = require('./respond-to-user')
 
+async function doUnsubscribe(phone) {
+  const subscribers = await knex('subscribers').where('phone', phone);
+  // Delete subscriber and any associated descriptions
+  subscribers.forEach(async subscriber => {
+    await knex('subscribers').delete().where('id', subscriber.id);
+    const subscriptions = await knex('subscriptions').where('subscriber_id', subscriber.id);
+    await knex('subscriptions').delete().where('subscriber_id', subscriber.id)
+
+    // Now delete any orphaned cases and defendants
+    subscriptions.forEach(async subscription => {
+      const defendants = await knex('defendants').where('id', subscription.defendant_id);
+      const count = await knex('subscriptions').where('defendant_id', subscription.defendant_id).count('*');
+      if (count[0]['count'] === 0 || count[0]['count'] == '0') {
+        await knex('cases').delete().where('defendant_id', subscription.defendant_id);
+        await knex('defendants').delete().where('id', subscription.defendant_id);
+      }
+    });
+  });
+}
 async function unsubscribe(req, res) {
   // Use req.body.From to get the number, 
   // look it up the database
   let message = 'Successfully unsubscribed!'
 
-  try {
-    const subscribers = await knex('subscribers').where('phone', req.body.From)
-    subscribers.forEach(async subscriber => {
-      await knex('subscriptions').delete().where('subscriber_id', subscriber.id)
-    })
+ try {
+    let phone = req.body.From;
+    if (phone.startsWith('+1')) {
+      phone = phone.substring(2);
+    }
+    doUnsubscribe(phone);
   } catch(e) {
     console.error(e)
     message = 'An error occurred. Subscribe unsuccessful'
@@ -21,5 +41,6 @@ async function unsubscribe(req, res) {
 }
 
 module.exports = {
-  unsubscribe
+  unsubscribe,
+  doUnsubscribe // This is for testing outside of post
 }

--- a/server/scripts/twilio/webhook-parser.js
+++ b/server/scripts/twilio/webhook-parser.js
@@ -46,7 +46,7 @@ const actions = require('./actions')
 const respondToUser = require('./respond-to-user')
 
 const verbs = {
-  unsubscribe: ['stop', 'unsubscribe', 'cancel']
+  unsubscribe: ['stop', 'stopall', 'unsubscribe', 'cancel', 'end', 'quit']
 }
 
 /**


### PR DESCRIPTION
Closes #40

**Please check if the PR fulfills these requirements**
- [x ] The title contains the issue number if fulfills and a concise description of the changes
- [ x] These changes are related to an open issue


**What changes are you introducing?**
When an unsubscribe notification is received (generally from Twilio), it now not only deletes the subscriber, but also any orphaned subscriptions, defendants and cases. I also pulled out the actual unsubscribe logic into a separate function so I could test from elsewhere in the code (I was having trouble getting test-webhook.js to work).
