### PR TITLE
Add encodeURI on name for URL to AOC site charges lookup

### DIFF
--- a/server/scripts/computeUrlName.js
+++ b/server/scripts/computeUrlName.js
@@ -1,8 +1,9 @@
+
 function computeUrlName(defendant) {
   let name = defendant.last_name + ',' + defendant.first_name;
   if (defendant.middle_name) name += ',' + defendant.middle_name;
   if (defendant.suffix) name += ',' + defendant.suffix; 
-  return name;
+  return encodeURI(name);
 }
 
 module.exports = {


### PR DESCRIPTION
Needed to call encodeURI in generating the URL to look up charges on the AOC site since some names have spaces in them.