### PR TITLE
Turned off Twilio message for register sub in develop mode #156

### DIFF
--- a/packages/server/register-subscription.js
+++ b/packages/server/register-subscription.js
@@ -49,7 +49,7 @@ async function registerSubscription(req, callback) {
       urlname: computeUrlName(defendant)
     }
 
-    if (process.env.NODE_ENV == 'production' || process.env.ENABLE_TWILIO_SMS == 'true') {
+    if (process.env.NODE_ENV == 'production' || process.env.DISABLE_SMS !== 'true') {
       let msg = Mustache.render(nameTemplate, defendantDetails);
       try {
         await client.messages

--- a/packages/server/register-subscription.js
+++ b/packages/server/register-subscription.js
@@ -49,29 +49,32 @@ async function registerSubscription(req, callback) {
       urlname: computeUrlName(defendant)
     }
 
-    let msg = Mustache.render(nameTemplate, defendantDetails);
-    try {
-      await client.messages
-          .create({
-            body: msg,
-            from: fromTwilioPhone,
-            statusCallback: process.env.TWILIO_SEND_STATUS_WEBHOOK_URL,
-            to: phone
-          })
-          .then(async function(message) {
-            logger.debug('Successfully sent subscription confirmation: ' + message.body);
-            logSubscription(defendant, cases, req.language);
-          });
-    } catch (e) {
-      unsubscribe(phone);
-      if (e.code === 21610) {
-        msg = Mustache.render(req.t("error-start"), { phone: process.env.TWILIO_PHONE_NUMBER});
+    if (String(process.env.NODE_ENV) !== "development") {
+      let msg = Mustache.render(nameTemplate, defendantDetails);
+      try {
+        await client.messages
+            .create({
+              body: msg,
+              from: fromTwilioPhone,
+              statusCallback: process.env.TWILIO_SEND_STATUS_WEBHOOK_URL,
+              to: phone
+            })
+            .then(async function (message) {
+              logger.debug('Successfully sent subscription confirmation: ' + message.body);
+             await logSubscription(defendant, cases, req.language);
+            });
+      } catch (e) {
+        await unsubscribe(phone);
+        if (e.code === 21610) {
+          msg = Mustache.render(req.t("error-start"), {phone: process.env.TWILIO_PHONE_NUMBER});
+          throw msg;
+        }
+        msg = req.t("error-unknown") + ' ' + e.message + '(' + e.code + ')';
+        logger.error('Error in register-subscription.js: ' + e.message + '(' + e.code + ')');
         throw msg;
       }
-      msg = req.t("error-unknown") + ' ' + e.message + '(' + e.code + ')';
-      logger.error('Error in register-subscription.js: ' + e.message + '(' + e.code + ')');
-      throw msg;
     }
+
   }
   catch (e) {
     returnMessage = (typeof e === 'string') ? e : e.message;

--- a/packages/server/register-subscription.js
+++ b/packages/server/register-subscription.js
@@ -49,7 +49,7 @@ async function registerSubscription(req, callback) {
       urlname: computeUrlName(defendant)
     }
 
-    if (Boolean(process.env.TWILIO_NO_SMS)) {
+    if (process.env.NODE_ENV == 'production' || process.env.ENABLE_TWILIO_SMS == 'true') {
       let msg = Mustache.render(nameTemplate, defendantDetails);
       try {
         await client.messages

--- a/packages/server/register-subscription.js
+++ b/packages/server/register-subscription.js
@@ -49,7 +49,7 @@ async function registerSubscription(req, callback) {
       urlname: computeUrlName(defendant)
     }
 
-    if (String(process.env.NODE_ENV) !== "development") {
+    if (Boolean(process.env.TWILIO_NO_SMS)) {
       let msg = Mustache.render(nameTemplate, defendantDetails);
       try {
         await client.messages
@@ -61,10 +61,10 @@ async function registerSubscription(req, callback) {
             })
             .then(async function (message) {
               logger.debug('Successfully sent subscription confirmation: ' + message.body);
-             await logSubscription(defendant, cases, req.language);
+            logSubscription(defendant, cases, req.language);
             });
       } catch (e) {
-        await unsubscribe(phone);
+        unsubscribe(phone);
         if (e.code === 21610) {
           msg = Mustache.render(req.t("error-start"), {phone: process.env.TWILIO_PHONE_NUMBER});
           throw msg;

--- a/packages/server/sample.env
+++ b/packages/server/sample.env
@@ -15,4 +15,4 @@ TWILIO_PHONE_NUMBER=add-twilio-phone-number-here
 TWILIO_WEBHOOK_URL=add-twilio-webhook-here
 TWILIO_SEND_STATUS_WEBHOOK_URL=add-twilio-send-status-webhook-url-here
 TEST_PHONE_NUMBER=+1<number to use for local testing>
-ENABLE_TWILIO_SMS=true
+DISABLE_SMS=false

--- a/packages/server/sample.env
+++ b/packages/server/sample.env
@@ -15,3 +15,4 @@ TWILIO_PHONE_NUMBER=add-twilio-phone-number-here
 TWILIO_WEBHOOK_URL=add-twilio-webhook-here
 TWILIO_SEND_STATUS_WEBHOOK_URL=add-twilio-send-status-webhook-url-here
 TEST_PHONE_NUMBER=+1<number to use for local testing>
+TWILIO_NO_SMS=true

--- a/packages/server/sample.env
+++ b/packages/server/sample.env
@@ -15,4 +15,4 @@ TWILIO_PHONE_NUMBER=add-twilio-phone-number-here
 TWILIO_WEBHOOK_URL=add-twilio-webhook-here
 TWILIO_SEND_STATUS_WEBHOOK_URL=add-twilio-send-status-webhook-url-here
 TEST_PHONE_NUMBER=+1<number to use for local testing>
-TWILIO_NO_SMS=true
+ENABLE_TWILIO_SMS=true


### PR DESCRIPTION
---
name: " #156 Turned off Twilio message for register subscription in development mode"
about: "I'm ready to check in some code to fix an issue!"
title: "[07/29/2022]: [Turned off Twilio message for development register]"
assignee: colinalford
---

<!-- Add the issue number from Github that this issues closes immediately following the hash to link to an issue -->
Closes #156

**Please check if the PR fulfills these requirements**
- [x] The title contains the issue number if fulfills and a concise description of the changes
- [x] These changes are related to an open issue


**What changes are you introducing?**
I've wrapped Twilio message sender in registerSubscription function with an "if" closet, checking if current NODE_ENV mode !== "development". If mode equals "development", function skips sending a message to the client. 

```diff
-let msg = Mustache.render(nameTemplate, defendantDetails);

+if (String(process.env.NODE_ENV) !== "development") {
+let msg = Mustache.render(nameTemplate, defendantDetails);
+...
+}
}
``` 

I also fixed the call of 2 async function without "await" keyword (line 64 and 67 on the screenshot):

```diff

-logSubscription(defendant, cases, req.language);
-unsubscribe(phone);

+await logSubscription(defendant, cases, req.language);
+await unsubscribe(phone);
```

I should have probably moved those last 2 fixes in other pull request.


**Screenshots or Video**:
![image](https://user-images.githubusercontent.com/78924110/181845504-c8f5a9ef-1203-4123-b68b-7edac977b136.png)
